### PR TITLE
Fix RMCP session numbers not being correct when no session is established

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,8 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 licensed as above, without any additional terms or conditions.
+
+This project aims to conform to [Conventional Commits]. If you make contributions,
+please be so kind to stick to that format :)
+
+[Conventional Commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary

--- a/src/app/auth/activate_session.rs
+++ b/src/app/auth/activate_session.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::connection::{IpmiCommand, Message, NetFn, ParseResponseError};
 
 use super::{AuthType, PrivilegeLevel};
@@ -13,7 +15,7 @@ pub struct ActivateSession {
 #[derive(Debug, Clone)]
 pub struct BeginSessionInfo {
     pub auth_type: AuthType,
-    pub session_id: u32,
+    pub session_id: NonZeroU32,
     pub initial_sequence_number: u32,
     pub maximum_privilege_level: PrivilegeLevel,
 }
@@ -47,7 +49,8 @@ impl IpmiCommand for ActivateSession {
         }
 
         let auth_type = data[0].try_into().map_err(|_| ())?;
-        let session_id = u32::from_le_bytes(data[1..5].try_into().unwrap());
+        let session_id = NonZeroU32::try_from(u32::from_le_bytes(data[1..5].try_into().unwrap()))
+            .map_err(|_| ())?;
         let initial_sequence_number = u32::from_le_bytes(data[5..9].try_into().unwrap());
         let maximum_privilege_level = data[9].try_into().map_err(|_| ())?;
 

--- a/src/app/auth/get_session_challenge.rs
+++ b/src/app/auth/get_session_challenge.rs
@@ -1,10 +1,12 @@
+use std::num::NonZeroU32;
+
 use crate::connection::{CompletionCode, IpmiCommand, Message, NetFn, ParseResponseError};
 
 use super::AuthType;
 
 #[derive(Debug, Clone, Copy)]
 pub struct SessionChallenge {
-    pub temporary_session_id: u32,
+    pub temporary_session_id: NonZeroU32,
     pub challenge_string: [u8; 16],
 }
 
@@ -69,7 +71,9 @@ impl IpmiCommand for GetSessionChallenge {
             return Err(ParseResponseError::NotEnoughData);
         }
 
-        let temporary_session_id = u32::from_le_bytes(data[0..4].try_into().unwrap());
+        let temporary_session_id =
+            NonZeroU32::try_from(u32::from_le_bytes(data[0..4].try_into().unwrap()))
+                .map_err(|_| ())?;
 
         let challenge_string = data[4..20].try_into().unwrap();
 

--- a/src/app/auth/get_session_challenge.rs
+++ b/src/app/auth/get_session_challenge.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use crate::connection::{CompletionCode, IpmiCommand, Message, NetFn, ParseResponseError};
 
-use super::AuthType;
+use super::{AuthError, AuthType};
 
 #[derive(Debug, Clone, Copy)]
 pub struct SessionChallenge {
@@ -59,7 +59,7 @@ impl Into<Message> for GetSessionChallenge {
 impl IpmiCommand for GetSessionChallenge {
     type Output = SessionChallenge;
 
-    type Error = ();
+    type Error = AuthError;
 
     fn parse_response(
         completion_code: CompletionCode,
@@ -73,7 +73,7 @@ impl IpmiCommand for GetSessionChallenge {
 
         let temporary_session_id =
             NonZeroU32::try_from(u32::from_le_bytes(data[0..4].try_into().unwrap()))
-                .map_err(|_| ())?;
+                .map_err(|_| AuthError::InvalidZeroSession)?;
 
         let challenge_string = data[4..20].try_into().unwrap();
 

--- a/src/app/auth/mod.rs
+++ b/src/app/auth/mod.rs
@@ -11,6 +11,17 @@ pub use get_session_challenge::{GetSessionChallenge, SessionChallenge};
 mod activate_session;
 pub use activate_session::{ActivateSession, BeginSessionInfo};
 
+#[derive(Debug, Clone)]
+pub enum AuthError {
+    /// A non-zero session ID was received at a stage where
+    /// non-zero session numbers are not allowed.
+    InvalidZeroSession,
+    /// An invalid auth type was encountered.
+    InvalidAuthType(u8),
+    /// An unknown privilege level was encountered.
+    InvalidPrivilegeLevel(u8),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AuthType {
     None,

--- a/src/app/get_channel_authentication_capabilities.rs
+++ b/src/app/get_channel_authentication_capabilities.rs
@@ -161,7 +161,7 @@ impl IpmiCommand for GetChannelAuthenticationCapabilities {
             anonymous_login_enabled: ale,
             ipmi2_connections_supported: v2,
             ipmi15_connections_supported: v15,
-            oem_id: oem_id,
+            oem_id,
             oem_auxiliary_data: oem_aux,
         })
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,9 @@
 mod get_device_id;
 pub use get_device_id::{DeviceId, GetDeviceId};
 
+mod get_channel_authentication_capabilities;
+pub use get_channel_authentication_capabilities::{
+    Channel, ChannelAuthenticationCapabilities, GetChannelAuthenticationCapabilities,
+};
+
 pub mod auth;

--- a/src/connection/impls/rmcp/encapsulation.rs
+++ b/src/connection/impls/rmcp/encapsulation.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU32;
+
 use crate::app::auth;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -23,7 +25,7 @@ impl AuthType {
     pub fn calculate(
         auth_type: auth::AuthType,
         password: &[u8; 16],
-        session_id: u32,
+        session_id: Option<NonZeroU32>,
         session_seq: u32,
         data: &[u8],
     ) -> AuthType {
@@ -33,7 +35,7 @@ impl AuthType {
             auth::AuthType::MD5 => {
                 let mut context = md5::Context::new();
                 context.consume(password);
-                context.consume(&session_id.to_le_bytes());
+                context.consume(&session_id.map(|v| v.get()).unwrap_or(0).to_le_bytes());
                 context.consume(data);
                 context.consume(session_seq.to_le_bytes());
                 context.consume(password);

--- a/src/connection/impls/rmcp/mod.rs
+++ b/src/connection/impls/rmcp/mod.rs
@@ -3,7 +3,6 @@
 
 use std::{
     io::{Error, ErrorKind},
-    iter::FusedIterator,
     net::{ToSocketAddrs, UdpSocket},
     num::NonZeroU32,
     time::Duration,
@@ -14,15 +13,15 @@ use crate::{
         self, ActivateSession, AuthError, Channel, GetChannelAuthenticationCapabilities,
         GetSessionChallenge, PrivilegeLevel,
     },
-    connection::{IpmiConnection, LogicalUnit, Message, Response},
+    connection::{IpmiConnection, LogicalUnit, Response},
     IpmiCommandError,
 };
 
 mod rmcp;
+mod wire;
 use rmcp::*;
 
 mod encapsulation;
-use encapsulation::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Inactive;
@@ -45,40 +44,6 @@ pub struct Rmcp<T> {
 }
 
 impl<T> Rmcp<T> {
-    fn checksum(data: impl IntoIterator<Item = u8>) -> impl Iterator<Item = u8> {
-        struct ChecksumIterator<I> {
-            checksum: u8,
-            yielded_checksum: bool,
-            inner: I,
-        }
-
-        impl<I: Iterator<Item = u8>> Iterator for ChecksumIterator<I> {
-            type Item = u8;
-
-            fn next(&mut self) -> Option<Self::Item> {
-                if let Some(value) = self.inner.next() {
-                    self.checksum = self.checksum.wrapping_add(value);
-                    Some(value)
-                } else if !self.yielded_checksum {
-                    self.yielded_checksum = true;
-                    self.checksum = !self.checksum;
-                    self.checksum = self.checksum.wrapping_add(1);
-                    Some(self.checksum)
-                } else {
-                    None
-                }
-            }
-        }
-
-        impl<I: Iterator<Item = u8>> FusedIterator for ChecksumIterator<I> {}
-
-        ChecksumIterator {
-            checksum: 0,
-            yielded_checksum: false,
-            inner: data.into_iter(),
-        }
-    }
-
     fn convert<O>(self, new_state: O) -> Rmcp<O> {
         Rmcp {
             inner: self.inner,
@@ -275,103 +240,23 @@ impl IpmiConnection for Rmcp<Active> {
     type Error = Error;
 
     fn send(&mut self, request: &mut crate::connection::Request) -> Result<(), Self::SendError> {
-        log::trace!("Sending message with auth type {:?}", self.state.auth_type);
-
-        let rs_addr = self.responder_addr;
-        let netfn_rslun: u8 = (request.netfn().request_value() << 2) | request.lun().value();
-
-        let first_part = Self::checksum([rs_addr, netfn_rslun]);
-
-        let req_addr = self.requestor_addr;
-
-        let ipmb_sequence = self.ipmb_sequence;
-        self.ipmb_sequence = self.ipmb_sequence.wrapping_add(1);
-
-        let reqseq_lun = (ipmb_sequence << 2) | self.requestor_lun.value();
-        let cmd = request.cmd();
-        let second_part = Self::checksum(
-            [req_addr, reqseq_lun, cmd]
-                .into_iter()
-                .chain(request.data().iter().map(|v| *v)),
-        );
-
-        let final_data: Vec<_> = first_part.chain(second_part).collect();
-
-        let session_sequence = self.state.request_sequence;
-
-        // Only increment the request sequence once a session has been established
-        // succesfully.
-        if self.state.session_id.is_some() {
-            self.state.request_sequence = self.state.request_sequence.wrapping_add(1);
-        }
-
-        let auth_type = AuthType::calculate(
+        wire::send(
+            &mut self.inner,
             self.state.auth_type,
-            &self.state.password,
+            self.requestor_addr,
+            self.responder_addr,
+            &mut self.ipmb_sequence,
+            self.requestor_lun,
+            &mut self.state.request_sequence,
             self.state.session_id,
-            session_sequence,
-            &final_data,
-        );
-
-        let message = RmcpMessage::new(
-            0xFF,
-            RmcpClass::IPMI(EncapsulatedMessage {
-                auth_type,
-                session_sequence,
-                session_id: self.state.session_id.map(|v| v.get()).unwrap_or(0),
-                payload: final_data,
-            }),
-        );
-
-        self.inner.send(&message.to_bytes())?;
-        Ok(())
+            &self.state.password,
+            request,
+        )
+        .map(|_| ())
     }
 
     fn recv(&mut self) -> Result<Response, Self::RecvError> {
-        let mut buffer = [0u8; 1024];
-        let received_bytes = self.inner.recv(&mut buffer)?;
-
-        if received_bytes < 8 {
-            return Err(Error::new(ErrorKind::Other, "Incomplete response"));
-        }
-
-        let data = &buffer[..received_bytes];
-
-        let rcmp_message = RmcpMessage::from_bytes(data)
-            .ok_or(Error::new(ErrorKind::Other, "RMCP response not recognized"))?;
-
-        let encapsulated_message = if let RmcpMessage {
-            class_and_contents: RmcpClass::IPMI(message),
-            ..
-        } = rcmp_message
-        {
-            message
-        } else {
-            return Err(Error::new(
-                ErrorKind::Other,
-                "RMCP response does not have IPMI class",
-            ));
-        };
-
-        let data = encapsulated_message.payload;
-
-        let _req_addr = data[0];
-        let netfn = data[1] >> 2;
-        let _checksum1 = data[2];
-        let _rs_addr = data[3];
-        let _rqseq = data[4];
-        let cmd = data[5];
-        let response_data: Vec<_> = data[6..data.len() - 1].iter().map(|v| *v).collect();
-        let _checksum2 = data[data.len() - 1];
-
-        let response =
-            if let Some(resp) = Response::new(Message::new_raw(netfn, cmd, response_data), 0) {
-                resp
-            } else {
-                return Err(Error::new(ErrorKind::Other, "Response data was empty"));
-            };
-
-        Ok(response)
+        wire::recv(&mut self.inner)
     }
 
     fn send_recv(
@@ -381,10 +266,4 @@ impl IpmiConnection for Rmcp<Active> {
         self.send(request)?;
         self.recv()
     }
-}
-
-#[test]
-pub fn checksum() {
-    let output: Vec<_> = Rmcp::<Inactive>::checksum([0x20, 0x06 << 2]).collect();
-    panic!("{:02X?}", output);
 }

--- a/src/connection/impls/rmcp/mod.rs
+++ b/src/connection/impls/rmcp/mod.rs
@@ -11,8 +11,8 @@ use std::{
 
 use crate::{
     app::auth::{
-        self, ActivateSession, Channel, GetChannelAuthenticationCapabilities, GetSessionChallenge,
-        PrivilegeLevel,
+        self, ActivateSession, AuthError, Channel, GetChannelAuthenticationCapabilities,
+        GetSessionChallenge, PrivilegeLevel,
     },
     connection::{IpmiConnection, LogicalUnit, Message, Response},
     IpmiCommandError,
@@ -100,8 +100,8 @@ pub enum ActivationError {
     PasswordTooLong,
     NoSupportedAuthenticationType,
     GetChannelAuthenticationCapabilities(CommandError<()>),
-    GetSessionChallenge(CommandError<()>),
-    ActivateSession(CommandError<()>),
+    GetSessionChallenge(CommandError<AuthError>),
+    ActivateSession(CommandError<AuthError>),
 }
 
 impl From<std::io::Error> for ActivationError {

--- a/src/connection/impls/rmcp/wire.rs
+++ b/src/connection/impls/rmcp/wire.rs
@@ -1,0 +1,171 @@
+use std::{
+    io::{Error, ErrorKind},
+    iter::FusedIterator,
+    net::UdpSocket,
+    num::NonZeroU32,
+};
+
+use crate::{
+    app::auth,
+    connection::{
+        rmcp::{
+            encapsulation::EncapsulatedMessage,
+            rmcp::{RmcpClass, RmcpMessage},
+        },
+        LogicalUnit, Message, Request, Response,
+    },
+};
+
+use super::encapsulation::AuthType;
+
+pub fn checksum(data: impl IntoIterator<Item = u8>) -> impl Iterator<Item = u8> + FusedIterator {
+    struct ChecksumIterator<I> {
+        checksum: u8,
+        yielded_checksum: bool,
+        inner: I,
+    }
+
+    impl<I: Iterator<Item = u8>> Iterator for ChecksumIterator<I> {
+        type Item = u8;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if let Some(value) = self.inner.next() {
+                self.checksum = self.checksum.wrapping_add(value);
+                Some(value)
+            } else if !self.yielded_checksum {
+                self.yielded_checksum = true;
+                self.checksum = !self.checksum;
+                self.checksum = self.checksum.wrapping_add(1);
+                Some(self.checksum)
+            } else {
+                None
+            }
+        }
+    }
+
+    impl<I: Iterator<Item = u8>> FusedIterator for ChecksumIterator<I> {}
+
+    ChecksumIterator {
+        checksum: 0,
+        yielded_checksum: false,
+        inner: data.into_iter(),
+    }
+}
+
+pub fn send(
+    inner: &mut UdpSocket,
+    auth_type: auth::AuthType,
+    requestor_addr: u8,
+    responder_addr: u8,
+    ipmb_sequence: &mut u8,
+    requestor_lun: LogicalUnit,
+    request_sequence: &mut u32,
+    session_id: Option<NonZeroU32>,
+    password: &[u8; 16],
+    request: &mut Request,
+) -> std::io::Result<usize> {
+    log::trace!("Sending message with auth type {:?}", auth_type);
+
+    let rs_addr = responder_addr;
+    let netfn_rslun: u8 = (request.netfn().request_value() << 2) | request.lun().value();
+
+    let first_part = checksum([rs_addr, netfn_rslun]);
+
+    let req_addr = requestor_addr;
+
+    let ipmb_sequence_val = *ipmb_sequence;
+    *ipmb_sequence = ipmb_sequence.wrapping_add(1);
+    let ipmb_sequence = ipmb_sequence_val;
+
+    let reqseq_lun = (ipmb_sequence << 2) | requestor_lun.value();
+    let cmd = request.cmd();
+    let second_part = checksum(
+        [req_addr, reqseq_lun, cmd]
+            .into_iter()
+            .chain(request.data().iter().map(|v| *v)),
+    );
+
+    let final_data: Vec<_> = first_part.chain(second_part).collect();
+
+    let session_sequence = *request_sequence;
+
+    // Only increment the request sequence once a session has been established
+    // succesfully.
+    if session_id.is_some() {
+        *request_sequence = request_sequence.wrapping_add(1);
+    }
+
+    let auth_type = AuthType::calculate(
+        auth_type,
+        password,
+        session_id,
+        session_sequence,
+        &final_data,
+    );
+
+    let message = RmcpMessage::new(
+        0xFF,
+        RmcpClass::IPMI(EncapsulatedMessage {
+            auth_type,
+            session_sequence,
+            session_id: session_id.map(|v| v.get()).unwrap_or(0),
+            payload: final_data,
+        }),
+    );
+
+    inner.send(&message.to_bytes())
+}
+
+pub fn recv(inner: &mut UdpSocket) -> Result<Response, Error> {
+    let mut buffer = [0u8; 1024];
+    let received_bytes = inner.recv(&mut buffer)?;
+
+    if received_bytes < 8 {
+        return Err(Error::new(ErrorKind::Other, "Incomplete response"));
+    }
+
+    let data = &buffer[..received_bytes];
+
+    let rcmp_message = RmcpMessage::from_bytes(data)
+        .ok_or(Error::new(ErrorKind::Other, "RMCP response not recognized"))?;
+
+    let encapsulated_message = if let RmcpMessage {
+        class_and_contents: RmcpClass::IPMI(message),
+        ..
+    } = rcmp_message
+    {
+        message
+    } else {
+        return Err(Error::new(
+            ErrorKind::Other,
+            "RMCP response does not have IPMI class",
+        ));
+    };
+
+    let data = encapsulated_message.payload;
+
+    let _req_addr = data[0];
+    let netfn = data[1] >> 2;
+    let _checksum1 = data[2];
+    let _rs_addr = data[3];
+    let _rqseq = data[4];
+    let cmd = data[5];
+    let response_data: Vec<_> = data[6..data.len() - 1].iter().map(|v| *v).collect();
+    let _checksum2 = data[data.len() - 1];
+
+    // TODO: validate sequence, checksums, etc.
+
+    let response = if let Some(resp) = Response::new(Message::new_raw(netfn, cmd, response_data), 0)
+    {
+        resp
+    } else {
+        return Err(Error::new(ErrorKind::Other, "Response data was empty"));
+    };
+
+    Ok(response)
+}
+
+#[test]
+pub fn checksum_test() {
+    let _output: Vec<_> = checksum([0x20, 0x06 << 2]).collect();
+}


### PR DESCRIPTION
See title.

Also add a note about Conventional Commits, and add some better auth error types.