### PR TITLE
support reading sensors that need to be bridged to ipmb address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,7 @@
 # Unreleased
-* Support for sending bridged IPMB messages for sensors that are not available on the system interface.
-  `GetSensorReading::new()` and `GetSensorReading::for_sensor()` have been replaced with
-  `GetSensorReading::for_sensor_key()` which now takes a `&Sensorkey`. ([#6])
-  * Currently, this is only implemented for file-based connections - RMCP is not supported yet.
-  * We determine whether a sensor is available on the system interface by checking
-    the value for the sensor owner ID and comparing it to the value returned by the
-    `ipmi_get_my_address` ioctl. If the ioctl fails, we assume the default address of 0x20.
-    This may break on systems that use a non-standard default address and do not return that
-    address.
+* Support for sending bridged IPMB messages for sensors that are not available on the system
+  interface for File-based connections. `GetSensorReading::new()` and `GetSensorReading::for_sensor()`
+  have been replaced with`GetSensorReading::for_sensor_key()` which now takes a `&Sensorkey`. ([#6])
 
 [#6]: https://github.com/datdenkikniet/ipmi-rs/pull/6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Unreleased
-No changes.
+* Support for sending bridged IPMB messages for sensors that are not available on the system interface.
+  `GetSensorReading::new()` and `GetSensorReading::for_sensor()` have been replaced with
+  `GetSensorReading::for_sensor_key()` which now takes a `&Sensorkey`. ([#6])
+  * Currently, this is only implemented for file-based connections - RMCP is not supported yet.
+  * We determine whether a sensor is available on the system interface by checking
+    the value for the sensor owner ID and comparing it to the value returned by the
+    `ipmi_get_my_address` ioctl. If the ioctl fails, we assume the default address of 0x20.
+    This may break on systems that use a non-standard default address and do not return that
+    address.
+
+[#6]: https://github.com/datdenkikniet/ipmi-rs/pull/6
 
 # [0.2.1](https://github.com/datdenkikniet/ipmi-rs/tree/v0.2.1)
 

--- a/examples/get-info.rs
+++ b/examples/get-info.rs
@@ -88,7 +88,7 @@ fn main() -> std::io::Result<()> {
     for sensor in &sensors {
         if let RecordContents::FullSensor(full) = &sensor.contents {
             let value = ipmi
-                .send_recv(GetSensorReading::for_sensor(full.sensor_number()))
+                .send_recv(GetSensorReading::for_sensor_key(full.key_data()))
                 .unwrap();
 
             let reading: ThresholdReading = (&value).into();

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use common::CommonOpts;
+use ipmi_rs::connection::RequestTargetAddress;
 use ipmi_rs::{
     connection::Message,
     connection::{IpmiConnection, LogicalUnit, Request},
@@ -53,7 +54,7 @@ fn main() -> std::io::Result<()> {
 
     let message = try_parse_message(&data)?;
 
-    let mut request: Request = Request::new(message, LogicalUnit::Zero, None);
+    let mut request: Request = Request::new(message, RequestTargetAddress::Bmc(LogicalUnit::Zero));
 
     let ipmi = command.common.get_connection()?;
 

--- a/examples/raw.rs
+++ b/examples/raw.rs
@@ -53,7 +53,7 @@ fn main() -> std::io::Result<()> {
 
     let message = try_parse_message(&data)?;
 
-    let mut request: Request = Request::new(message, LogicalUnit::Zero);
+    let mut request: Request = Request::new(message, LogicalUnit::Zero, None);
 
     let ipmi = command.common.get_connection()?;
 

--- a/examples/sensors-of-type.rs
+++ b/examples/sensors-of-type.rs
@@ -58,7 +58,7 @@ fn main() -> std::io::Result<()> {
         if let RecordContents::FullSensor(full) = sdr.contents {
             if args.reading {
                 let value = ipmi
-                    .send_recv(GetSensorReading::for_sensor(full.sensor_number()))
+                    .send_recv(GetSensorReading::for_sensor_key(full.key_data()))
                     .unwrap();
 
                 let reading: ThresholdReading = (&value).into();

--- a/src/connection/impls/file.rs
+++ b/src/connection/impls/file.rs
@@ -255,9 +255,13 @@ impl IpmiConnection for File {
     type Error = io::Error;
 
     fn send(&mut self, request: &mut Request) -> io::Result<()> {
-        let mut addr: IpmiAddr = request
-            .bridge_target_address_and_channel(self.my_addr)
-            .into();
+        let mut addr: IpmiAddr = match request.target() {
+            RequestTargetAddress::BmcOrIpmb(a, _, lun) if a == self.my_addr => {
+                RequestTargetAddress::Bmc(lun)
+            }
+            x => x,
+        }
+        .into();
 
         let netfn = request.netfn_raw();
         let cmd = request.cmd();

--- a/src/connection/impls/rmcp/wire.rs
+++ b/src/connection/impls/rmcp/wire.rs
@@ -67,7 +67,7 @@ pub fn send(
     log::trace!("Sending message with auth type {:?}", auth_type);
 
     let rs_addr = responder_addr;
-    let netfn_rslun: u8 = (request.netfn().request_value() << 2) | request.lun().value();
+    let netfn_rslun: u8 = (request.netfn().request_value() << 2) | request.target().lun().value();
 
     let first_part = checksum([rs_addr, netfn_rslun]);
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -12,7 +12,7 @@ mod netfn;
 pub use netfn::NetFn;
 
 mod request;
-pub use request::Request;
+pub use request::{Address, Channel, Request, RequestTargetAddress};
 
 mod response;
 pub use response::Response;
@@ -49,17 +49,6 @@ impl LogicalUnit {
             LogicalUnit::Three => 3,
         }
     }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Address(pub u8);
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub struct Channel(pub u8);
-
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum RequestTargetAddress {
-    Bmc(LogicalUnit),
-    BmcOrIpmb(Address, Channel, LogicalUnit),
 }
 
 pub trait IpmiConnection {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -51,6 +51,17 @@ impl LogicalUnit {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Address(pub u8);
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Channel(pub u8);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RequestTargetAddress {
+    Bmc(LogicalUnit),
+    BmcOrIpmb(Address, Channel, LogicalUnit),
+}
+
 pub trait IpmiConnection {
     type SendError: core::fmt::Debug;
     type RecvError: core::fmt::Debug;
@@ -140,7 +151,7 @@ pub trait IpmiCommand: Into<Message> {
         }
     }
 
-    fn address_and_channel(&self) -> Option<(u8, u8)> {
+    fn target(&self) -> Option<(Address, Channel)> {
         None
     }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -139,4 +139,8 @@ pub trait IpmiCommand: Into<Message> {
             Err(ParseResponseError::Failed(cc))
         }
     }
+
+    fn address_and_channel(&self) -> Option<(u8, u8)> {
+        None
+    }
 }

--- a/src/connection/request.rs
+++ b/src/connection/request.rs
@@ -1,4 +1,4 @@
-use crate::connection::{LogicalUnit, NetFn, RequestTargetAddress};
+use crate::connection::{LogicalUnit, NetFn};
 
 use super::Message;
 
@@ -23,13 +23,6 @@ impl Request {
         self.message.netfn_raw()
     }
 
-    pub fn lun(&self) -> LogicalUnit {
-        match self.target {
-            RequestTargetAddress::Bmc(lun) => lun,
-            RequestTargetAddress::BmcOrIpmb(_, _, lun) => lun,
-        }
-    }
-
     pub fn cmd(&self) -> u8 {
         self.message.cmd
     }
@@ -44,5 +37,26 @@ impl Request {
 
     pub fn target(&self) -> RequestTargetAddress {
         self.target
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Address(pub u8);
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Channel(pub u8);
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum RequestTargetAddress {
+    Bmc(LogicalUnit),
+    BmcOrIpmb(Address, Channel, LogicalUnit),
+}
+
+impl RequestTargetAddress {
+    pub fn lun(&self) -> LogicalUnit {
+        match self {
+            RequestTargetAddress::Bmc(lun) | RequestTargetAddress::BmcOrIpmb(_, _, lun) => {
+                lun.clone()
+            }
+        }
     }
 }

--- a/src/connection/request.rs
+++ b/src/connection/request.rs
@@ -1,4 +1,4 @@
-use crate::connection::{Address, LogicalUnit, NetFn, RequestTargetAddress};
+use crate::connection::{LogicalUnit, NetFn, RequestTargetAddress};
 
 use super::Message;
 
@@ -42,12 +42,7 @@ impl Request {
         self.message.data_mut()
     }
 
-    pub fn bridge_target_address_and_channel(&self, my_addr: Address) -> RequestTargetAddress {
-        match self.target {
-            RequestTargetAddress::BmcOrIpmb(a, _, lun) if a == my_addr => {
-                RequestTargetAddress::Bmc(lun)
-            }
-            x => x,
-        }
+    pub fn target(&self) -> RequestTargetAddress {
+        self.target
     }
 }

--- a/src/connection/request.rs
+++ b/src/connection/request.rs
@@ -5,13 +5,19 @@ use super::Message;
 pub struct Request {
     lun: LogicalUnit,
     message: Message,
+    address_and_channel: Option<(u8, u8)>,
 }
 
 impl Request {
-    pub const fn new(request: Message, lun: LogicalUnit) -> Self {
+    pub const fn new(
+        request: Message,
+        lun: LogicalUnit,
+        address_and_channel: Option<(u8, u8)>,
+    ) -> Self {
         Self {
             lun,
             message: request,
+            address_and_channel,
         }
     }
 
@@ -37,5 +43,18 @@ impl Request {
 
     pub fn data_mut(&mut self) -> &mut [u8] {
         self.message.data_mut()
+    }
+
+    pub fn bridge_target_address_and_channel(&self, my_addr: u8) -> Option<(u8, u8)> {
+        match self.address_and_channel {
+            Some((addr, channel)) => {
+                if addr != my_addr {
+                    Some((addr, channel))
+                } else {
+                    None
+                }
+            }
+            None => None,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ mod tests;
 
 pub use fmt::{LogOutput, Loggable, Logger};
 
-use connection::{IpmiCommand, LogicalUnit, NetFn, ParseResponseError, Request};
+use connection::{
+    IpmiCommand, LogicalUnit, NetFn, ParseResponseError, Request, RequestTargetAddress,
+};
 use storage::sdr::{self, record::Record as SdrRecord};
 
 pub struct Ipmi<CON> {
@@ -89,10 +91,13 @@ where
     where
         CMD: IpmiCommand,
     {
-        let address_and_channel = request.address_and_channel();
+        let target_address = match request.target() {
+            Some((a, c)) => RequestTargetAddress::BmcOrIpmb(a, c, LogicalUnit::Zero),
+            None => RequestTargetAddress::Bmc(LogicalUnit::Zero),
+        };
         let message = request.into();
         let (message_netfn, message_cmd) = (message.netfn(), message.cmd());
-        let mut request = Request::new(message, LogicalUnit::Zero, address_and_channel);
+        let mut request = Request::new(message, target_address);
 
         let response = self.inner.send_recv(&mut request)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,9 +89,10 @@ where
     where
         CMD: IpmiCommand,
     {
+        let address_and_channel = request.address_and_channel();
         let message = request.into();
         let (message_netfn, message_cmd) = (message.netfn(), message.cmd());
-        let mut request = Request::new(message, LogicalUnit::Zero);
+        let mut request = Request::new(message, LogicalUnit::Zero, address_and_channel);
 
         let response = self.inner.send_recv(&mut request)?;
 

--- a/src/sensor_event/sensor_reading/get.rs
+++ b/src/sensor_event/sensor_reading/get.rs
@@ -1,3 +1,4 @@
+use crate::storage::sdr::record::SensorKey;
 use crate::{
     connection::{CompletionCode, IpmiCommand, Message, ParseResponseError},
     storage::sdr::record::SensorNumber,
@@ -37,12 +38,21 @@ impl RawSensorReading {
 
 pub struct GetSensorReading {
     sensor_number: SensorNumber,
+    address_and_channel: Option<(u8, u8)>,
 }
 
 impl GetSensorReading {
     pub fn new(value: SensorNumber) -> Self {
         Self {
             sensor_number: value,
+            address_and_channel: None,
+        }
+    }
+
+    pub fn for_sensor_key(value: &SensorKey) -> Self {
+        Self {
+            sensor_number: value.sensor_number,
+            address_and_channel: Some((value.owner_id.into(), value.owner_channel)),
         }
     }
 
@@ -73,5 +83,8 @@ impl IpmiCommand for GetSensorReading {
         Self::check_cc_success(completion_code)?;
 
         RawSensorReading::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    }
+    fn address_and_channel(&self) -> Option<(u8, u8)> {
+        self.address_and_channel
     }
 }

--- a/src/storage/sdr/record/mod.rs
+++ b/src/storage/sdr/record/mod.rs
@@ -124,6 +124,15 @@ impl From<u8> for SensorOwner {
     }
 }
 
+impl Into<u8> for SensorOwner {
+    fn into(self) -> u8 {
+        match self {
+            Self::I2C(id) => (id << 1) & 0xFE,
+            Self::System(id) => ((id << 1) & 0xFE) | 1,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum EntityRelativeTo {
     System,
@@ -903,5 +912,19 @@ impl Loggable for Record {
         }
 
         log
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sensor_owner_round_trip() {
+        for x in 0u8..=255u8 {
+            let o = SensorOwner::from(x);
+            let value: u8 = o.into();
+            assert_eq!(x, value);
+        }
     }
 }


### PR DESCRIPTION
On some newer generations of HP hardware (output below is from an ML110 Gen10) we are not able to read all the sensors because they are not reachable directly from the BMC - we need to request that the request be bridged to the actual sensor.
```
...
 WARN  get_info > No reading for 31-PCI 6
 WARN  get_info > No reading for 32-PCI 7
 WARN  get_info > No reading for 33-PCI 8
 INFO  get_info > 34-PCI 1 Zone: 29.00 °C
 INFO  get_info > 35-PCI 2 Zone: 30.00 °C
 INFO  get_info > 36-PCI 3 Zone: 30.00 °C
 INFO  get_info > 37-PCI 4 Zone: 30.00 °C
 INFO  get_info > 38-PCI 5 Zone: 34.00 °C
 INFO  get_info > 39-PCI 6 Zone: 36.00 °C
 INFO  get_info > 40-PCI 7 Zone: 35.00 °C
 INFO  get_info > 41-PCI 8 Zone: 34.00 °C
 INFO  get_info > 43-Battery Zone: 33.00 °C
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ParsingFailed { error: Failed(RequestedDatapointNotPresent), netfn: SensorEvent, cmd: 45, completion_code: 203, data: [] }', examples/get-info.rs:92:18
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: core::result::Result<T,E>::unwrap
             at /home/buildozer/aports/community/rust/src/rustc-1.71.1-src/library/core/src/result.rs:1076:23
   4: get_info::main
             at ./examples/get-info.rs:90:25
   5: core::ops::function::FnOnce::call_once
             at /home/buildozer/aports/community/rust/src/rustc-1.71.1-src/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
With this change we are now able to read all the sensors succesfully.

```
...
 INFO  get_info > 36-PCI 3 Zone: 30.00 °C
 INFO  get_info > 37-PCI 4 Zone: 30.00 °C
 INFO  get_info > 38-PCI 5 Zone: 34.00 °C
 INFO  get_info > 39-PCI 6 Zone: 36.00 °C
 INFO  get_info > 40-PCI 7 Zone: 35.00 °C
 INFO  get_info > 41-PCI 8 Zone: 34.00 °C
 INFO  get_info > 43-Battery Zone: 33.00 °C
 INFO  get_info > 44-P/S 1 Inlet: 0.00 °C
 INFO  get_info > 45-P/S 2 Inlet: 35.00 °C
 INFO  get_info > 46-P/S 1: 0.00 °C
 INFO  get_info > 47-P/S 2: 46.00 °C
 INFO  get_info > 48-E-Fuse: 35.00 °C
 INFO  get_info > 49-P/S 2 Zone: 38.00 °C
 WARN  get_info > No reading for 50-AHCI HD Max
...
```
(there's something wrong with power supply 1 on this system, ipmitool shows the same numbers)

h2. Questions

* I'm not super happy with the way we decide what type of address to use in `send()`. Normally I'd create an enum and match on the variants, but I've run into issues before with unsafe code and stuff getting moved unexpectedly, so I wouldn't be confident it was sound.
* Should we keep `for_sensor()` around at all? At least one of our test systems (the Gen10 ML110 system again) re-uses the same sensor number for two different target addresses so I'm not entirely sure it's sound to just query the BMC with just the sensor number.
* Is the handling of channels and LUNs correct? I'll dig through the specification a bit more to see how these are used. None of the test systems we have show any sensors on a non-zero channel or LUN
* [ipmitool will use picmg or VITA](https://github.com/ipmitool/ipmitool/blob/19d78782d795d0cf4ceefe655f616210c9143e62/lib/ipmi_main.c#L292) if they are available to determine what base address to use. None of the test systems I have access to seem to have these available, some googling seems to indicate they are related to blade chassis.

Thanks again for taking the time to review - happy to address any comments or feedback.