### PR TITLE
fix(compact sensor): correctly parse alphabetic id string modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 * Support for sending bridged IPMB messages for sensors that are not available on the system
   interface for File-based connections. `GetSensorReading::new()` and `GetSensorReading::for_sensor()`
   have been replaced with`GetSensorReading::for_sensor_key()` which now takes a `&Sensorkey`. ([#6])
+* Fix parsing ID String modifier in `CompactSensorRecord` ([#7])
+
 
 [#6]: https://github.com/datdenkikniet/ipmi-rs/pull/6
+[#7]: https://github.com/datdenkikniet/ipmi-rs/pull/7
 
 # [0.2.1](https://github.com/datdenkikniet/ipmi-rs/tree/v0.2.1)
 

--- a/src/storage/sdr/record/compact_sensor_record.rs
+++ b/src/storage/sdr/record/compact_sensor_record.rs
@@ -48,7 +48,7 @@ impl CompactSensorRecord {
         let direction = Direction::try_from((direction_sharing_1 & 0xC) >> 6).unwrap();
         let id_string_instance_modifier = match (direction_sharing_1 & 0x30) >> 4 {
             0b00 => IdStringModifier::Numeric,
-            0b01 => IdStringModifier::Numeric,
+            0b01 => IdStringModifier::Alpha,
             _ => panic!("Invalid ID string modifier, no fallback available."),
         };
 


### PR DESCRIPTION
This should be a simple one, but I have two questions:
1. What do you think about refactoring these to use binary literals instead of hex literals for pulling out the right bits?
2. I don't love the number of cases under which these parse functions panic - Should they return a Result<> instead?