### PR TITLE
Add more SDR record types

### DIFF
--- a/examples/get-info.rs
+++ b/examples/get-info.rs
@@ -104,6 +104,9 @@ fn main() -> std::io::Result<()> {
         } else if let RecordContents::CompactSensor(compact) = &sensor.contents {
             log::info!("Compact sensor {}", compact.id_string(),);
             log::info!("  Sensor type: {:?}", compact.common().ty,);
+        } else if let RecordContents::FruDeviceLocator(fru_device_locator) = &sensor.contents {
+            log::info!("FRU Device Locator {}", fru_device_locator.id_string());
+            log::info!("  Device type: {}", fru_device_locator.device_type);
         } else if let RecordContents::Unknown { ty, .. } = &sensor.contents {
             log::info!("Unknown record type. Type: 0x{ty:02X}");
         }

--- a/examples/get-info.rs
+++ b/examples/get-info.rs
@@ -104,6 +104,9 @@ fn main() -> std::io::Result<()> {
         } else if let RecordContents::CompactSensor(compact) = &sensor.contents {
             log::info!("Compact sensor {}", compact.id_string(),);
             log::info!("  Sensor type: {:?}", compact.common().ty,);
+        } else if let RecordContents::EventOnlySensor(event) = &sensor.contents {
+            log::info!("Event-only sensor {}", event.id_string,);
+            log::info!("  Sensor type: {:?}", event.ty,);
         } else if let RecordContents::FruDeviceLocator(fru_device_locator) = &sensor.contents {
             log::info!("FRU Device Locator {}", fru_device_locator.id_string());
             log::info!("  Device type: {}", fru_device_locator.device_type);

--- a/examples/get-info.rs
+++ b/examples/get-info.rs
@@ -110,6 +110,8 @@ fn main() -> std::io::Result<()> {
         } else if let RecordContents::FruDeviceLocator(fru_device_locator) = &sensor.contents {
             log::info!("FRU Device Locator {}", fru_device_locator.id_string());
             log::info!("  Device type: {}", fru_device_locator.device_type);
+        } else if let RecordContents::McDeviceLocator(mc_device_locator) = &sensor.contents {
+            log::info!("MC Device Locator {}", mc_device_locator.id_string());
         } else if let RecordContents::Unknown { ty, .. } = &sensor.contents {
             log::info!("Unknown record type. Type: 0x{ty:02X}");
         }

--- a/src/storage/sdr/record/event_only_sensor_record.rs
+++ b/src/storage/sdr/record/event_only_sensor_record.rs
@@ -1,0 +1,69 @@
+use crate::storage::sdr::event_reading_type_code::EventReadingTypeCodes;
+use crate::storage::sdr::record::compact_sensor_record::{IdStringModifier, RecordSharing};
+use crate::storage::sdr::record::{Direction, EntityInstance, SensorId, SensorKey, TypeLengthRaw};
+use crate::storage::sdr::SensorType;
+
+#[derive(Debug, Clone)]
+
+pub struct EventOnlySensorRecord {
+    pub key: SensorKey,
+    pub entity_id: u8,
+    pub entity_instance: EntityInstance,
+    pub ty: SensorType,
+    pub event_reading_type_code: EventReadingTypeCodes,
+    pub direction: Direction,
+    pub record_sharing: RecordSharing,
+    pub oem_reserved: u8,
+    pub id_string: SensorId,
+}
+
+impl EventOnlySensorRecord {
+    pub fn parse(record_data: &[u8]) -> Option<Self> {
+        let key = SensorKey::parse(&record_data[..3])?;
+
+        let entity_id = record_data[3];
+        let entity_instance = EntityInstance::try_from(record_data[4]).ok()?;
+        let ty = record_data[5].into();
+        let event_reading_type_code = record_data[6].into();
+
+        let direction_sharing_1 = record_data[7];
+        let direction_sharing_2 = record_data[8];
+
+        let direction = Direction::try_from((direction_sharing_1 & 0xC) >> 6).unwrap();
+        let id_string_instance_modifier = match (direction_sharing_1 & 0x30) >> 4 {
+            0b00 => Some(IdStringModifier::Numeric),
+            0b01 => Some(IdStringModifier::Alpha),
+            _ => None,
+        }?;
+
+        let share_count = direction_sharing_1 & 0xF;
+        let entity_instance_increments = (direction_sharing_2 & 0x80) == 0x80;
+        let modifier_offset = direction_sharing_2 & 0x3F;
+
+        let record_sharing = RecordSharing {
+            id_string_modifier: id_string_instance_modifier,
+            share_count,
+            entity_instance_increments,
+            modifier_offset,
+        };
+
+        // one reserved byte
+        let oem_reserved = record_data[10];
+        let id_string_type_len = record_data[11];
+        let id_string_bytes = &record_data[12..];
+
+        let id_string = TypeLengthRaw::new(id_string_type_len, id_string_bytes).into();
+
+        Some(EventOnlySensorRecord {
+            key,
+            entity_id,
+            entity_instance,
+            ty,
+            event_reading_type_code,
+            direction,
+            record_sharing,
+            oem_reserved,
+            id_string,
+        })
+    }
+}

--- a/src/storage/sdr/record/fru_device_locator.rs
+++ b/src/storage/sdr/record/fru_device_locator.rs
@@ -1,0 +1,95 @@
+use crate::connection::LogicalUnit;
+use crate::storage::sdr::record::{SensorId, TypeLengthRaw};
+
+#[derive(Debug, Clone)]
+pub struct LogicalFruDevice {
+    pub fru_device_id: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct PhysicalFruDevice {
+    pub i2c_address: u8,
+}
+
+#[derive(Debug, Clone)]
+pub enum FruDevice {
+    Logical(LogicalFruDevice),
+    Physical(PhysicalFruDevice),
+}
+
+#[derive(Debug, Clone)]
+pub struct FruRecordKey {
+    pub device_access_address: u8,
+    pub fru_device: FruDevice,
+    pub lun: LogicalUnit,
+    pub private_bus_id: u8,
+    pub channel_number: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct FruDeviceLocator {
+    pub record_key: FruRecordKey,
+    pub device_type: u8,
+    pub device_type_modifier: u8,
+    pub fru_entity_id: u8,
+    pub fru_entity_instance: u8,
+    pub oem_reserved: u8,
+    pub id_string: SensorId,
+}
+
+impl FruDeviceLocator {
+    pub fn parse(record_data: &[u8]) -> Option<Self> {
+        if record_data.len() < 8 {
+            return None;
+        }
+
+        let device_access_address = record_data[0] >> 1;
+
+        let fru_device = if record_data[1] & 0x80 == 0x80 {
+            FruDevice::Physical(PhysicalFruDevice {
+                i2c_address: (record_data[1] >> 1),
+            })
+        } else {
+            FruDevice::Logical(LogicalFruDevice {
+                fru_device_id: record_data[1],
+            })
+        };
+
+        let lun = LogicalUnit::try_from((record_data[2] >> 3) & 0b11).ok()?;
+        let private_bus_id = record_data[2] & 0b111;
+        let channel_number = record_data[3];
+
+        let record_key = FruRecordKey {
+            device_access_address,
+            fru_device,
+            lun,
+            private_bus_id,
+            channel_number,
+        };
+
+        let device_type = record_data[5];
+        let device_type_modifier = record_data[6];
+        let fru_entity_id = record_data[7];
+        let fru_entity_instance = record_data[8];
+        let oem_reserved = record_data[9];
+
+        let id_string_type_len = record_data[10];
+        let id_string_bytes = &record_data[11..];
+
+        let id_string = TypeLengthRaw::new(id_string_type_len, id_string_bytes).into();
+
+        Some(Self {
+            record_key,
+            device_type,
+            device_type_modifier,
+            fru_entity_id,
+            fru_entity_instance,
+            oem_reserved,
+            id_string,
+        })
+    }
+
+    pub fn id_string(&self) -> &SensorId {
+        &self.id_string
+    }
+}

--- a/src/storage/sdr/record/mc_device_locator.rs
+++ b/src/storage/sdr/record/mc_device_locator.rs
@@ -1,0 +1,117 @@
+use crate::storage::sdr::record::{SensorId, TypeLengthRaw};
+
+#[derive(Debug, Clone)]
+pub struct McRecordKey {
+    pub i2c_address: u8,
+    pub channel: u8,
+}
+#[derive(Debug, Clone)]
+pub enum GlobalInitialization {
+    EnableEventMessageGeneration,
+    DisableEventMessageGeneration,
+    DoNotInitialize,
+    Reserved,
+}
+#[derive(Debug, Clone)]
+pub struct DeviceCapabilities {
+    pub chassis_device: bool,
+    pub bridge: bool,
+    pub ipmi_event_generator: bool,
+    pub ipmi_event_receiver: bool,
+    pub fru_inventory_device: bool,
+    pub sel_device: bool,
+    pub sdr_repository_device: bool,
+    pub sensor_device: bool,
+}
+#[derive(Debug, Clone)]
+pub struct McDeviceLocatorRecord {
+    pub key: McRecordKey,
+    pub acpi_system_power_state_notification_required: bool,
+    pub acpi_device_power_state_notification_required: bool,
+    pub static_controller: bool,
+
+    pub controller_logs_initialization_errors: bool,
+    pub log_initialization_errors_accessing_controller: bool,
+    pub global_initialization: GlobalInitialization,
+    pub device_capabilities: DeviceCapabilities,
+    pub entity_id: u8,
+    // Note: Unlike entity_instance in sensor SDRs, the IPMI specification specifies this as just
+    // an entity instance number, hence not using the `EntityInstance` type here.
+    pub entity_instance: u8,
+    pub oem_reserved: u8,
+    pub id_string: SensorId,
+}
+
+impl McDeviceLocatorRecord {
+    pub fn parse(record_data: &[u8]) -> Option<Self> {
+        let i2c_address = record_data[0] >> 1;
+        let channel = record_data[1] & 0b1111;
+
+        let key = McRecordKey {
+            i2c_address,
+            channel,
+        };
+
+        let psn_and_gi = record_data[2];
+        let acpi_system_power_state_notification_required =
+            (psn_and_gi & 0b1000_0000) == 0b1000_0000;
+        let acpi_device_power_state_notification_required =
+            (psn_and_gi & 0b0100_0000) == 0b0100_0000;
+        let static_controller = (psn_and_gi & 0b0010_0000) == 0b0010_0000;
+        // reserved bit
+        // should these bools be part of GlobalInitialization?
+        let controller_logs_initialization_errors = (record_data[2] & 0b0000_1000) == 0b0000_1000;
+        let log_initialization_errors_accessing_controller =
+            (record_data[2] & 0b0000_0100) == 0b0000_0100;
+        let global_initialization = match record_data[2] & 0b0000_0011 {
+            0b00 => GlobalInitialization::EnableEventMessageGeneration,
+            0b01 => GlobalInitialization::DisableEventMessageGeneration,
+            0b10 => GlobalInitialization::DoNotInitialize,
+            0b11 => GlobalInitialization::Reserved,
+            _ => unreachable!(),
+        };
+
+        let dc_byte = record_data[3];
+
+        let device_capabilities = DeviceCapabilities {
+            chassis_device: (dc_byte & 0b1000_0000) == 0b1000_0000,
+            bridge: (dc_byte & 0b0100_0000) == 0b0100_0000,
+            ipmi_event_generator: (dc_byte & 0b0010_0000) == 0b0010_0000,
+            ipmi_event_receiver: (dc_byte & 0b0001_0000) == 0b0001_0000,
+            fru_inventory_device: (dc_byte & 0b0000_1000) == 0b0000_1000,
+            sel_device: (dc_byte & 0b0000_0100) == 0b0000_0100,
+            sdr_repository_device: (dc_byte & 0b0000_0010) == 0b0000_0010,
+            sensor_device: (dc_byte & 0b0000_0001) == 0b0000_0001,
+        };
+
+        // 3 reserved bytes
+
+        let entity_id = record_data[7];
+        let entity_instance = record_data[8];
+        let oem_reserved = record_data[9];
+
+        let id_string_type_len = record_data[10];
+        let id_string_bytes = &record_data[11..];
+
+        let id_string = TypeLengthRaw::new(id_string_type_len, id_string_bytes).into();
+
+        Some(McDeviceLocatorRecord {
+            key,
+            acpi_system_power_state_notification_required,
+            acpi_device_power_state_notification_required,
+            static_controller,
+            controller_logs_initialization_errors,
+            log_initialization_errors_accessing_controller,
+            global_initialization,
+            device_capabilities,
+            entity_id,
+            entity_instance,
+            oem_reserved,
+            id_string,
+        })
+    }
+
+    pub fn id_string(&self) -> &SensorId {
+        &self.id_string
+    }
+}

--- a/src/storage/sdr/record/mod.rs
+++ b/src/storage/sdr/record/mod.rs
@@ -4,6 +4,7 @@ pub use full_sensor_record::FullSensorRecord;
 mod compact_sensor_record;
 mod event_only_sensor_record;
 mod fru_device_locator;
+mod mc_device_locator;
 
 pub use compact_sensor_record::CompactSensorRecord;
 
@@ -11,6 +12,7 @@ use nonmax::NonMaxU8;
 
 use crate::storage::sdr::record::event_only_sensor_record::EventOnlySensorRecord;
 use crate::storage::sdr::record::fru_device_locator::FruDeviceLocator;
+use crate::storage::sdr::record::mc_device_locator::McDeviceLocatorRecord;
 use crate::{connection::LogicalUnit, Loggable};
 
 use super::{event_reading_type_code::EventReadingTypeCodes, RecordId, SensorType, Unit};
@@ -704,6 +706,7 @@ pub enum RecordContents {
     CompactSensor(CompactSensorRecord),
     EventOnlySensor(EventOnlySensorRecord),
     FruDeviceLocator(FruDeviceLocator),
+    McDeviceLocator(McDeviceLocatorRecord),
     Unknown { ty: u8, data: Vec<u8> },
 }
 
@@ -714,6 +717,7 @@ impl Record {
             RecordContents::CompactSensor(s) => Some(s.common()),
             RecordContents::EventOnlySensor(_) => None,
             RecordContents::FruDeviceLocator(_) => None,
+            RecordContents::McDeviceLocator(_) => None,
             RecordContents::Unknown { .. } => None,
         }
     }
@@ -758,6 +762,8 @@ impl Record {
             RecordContents::EventOnlySensor(EventOnlySensorRecord::parse(record_data)?)
         } else if record_type == 0x11 {
             RecordContents::FruDeviceLocator(FruDeviceLocator::parse(record_data)?)
+        } else if record_type == 0x12 {
+            RecordContents::McDeviceLocator(McDeviceLocatorRecord::parse(record_data)?)
         } else {
             RecordContents::Unknown {
                 ty: record_type,
@@ -781,6 +787,7 @@ impl Record {
             RecordContents::CompactSensor(compact) => Some(compact.id_string()),
             RecordContents::EventOnlySensor(event) => Some(&event.id_string),
             RecordContents::FruDeviceLocator(fru) => Some(&fru.id_string),
+            RecordContents::McDeviceLocator(mc) => Some(&mc.id_string),
             RecordContents::Unknown { .. } => None,
         }
     }
@@ -790,7 +797,7 @@ impl Record {
             RecordContents::FullSensor(full) => Some(full.sensor_number()),
             RecordContents::CompactSensor(compact) => Some(compact.sensor_number()),
             RecordContents::EventOnlySensor(event) => Some(event.key.sensor_number),
-            RecordContents::FruDeviceLocator(_) => None,
+            RecordContents::FruDeviceLocator(_) | RecordContents::McDeviceLocator(_) => None,
             RecordContents::Unknown { .. } => None,
         }
     }


### PR DESCRIPTION
Creating as a draft PR as there is still some work to do.

Questions:
* 'event-only' sensors are missing some of the fields in `SensorRecordCommon`. There are a few options for handling this.
  * remove those fields from common
  * make them optional in common
  * break common into two types, one for Full+Compact, and one for all three

Still todo:
 * tidy up interfaces to be consistent
 * make `parse` methods return `Result<>` instead of `Option<>`
 * refactor out duplicated common parsing code