### PR TITLE
feat: validate sequence numbers for file connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
   interface for File-based connections. `GetSensorReading::new()` and `GetSensorReading::for_sensor()`
   have been replaced with`GetSensorReading::for_sensor_key()` which now takes a `&Sensorkey`. ([#6])
 * Fix parsing ID String modifier in `CompactSensorRecord` ([#7])
+* Validate sequence numbers for `File` connections. ([#11])
 
 
 [#6]: https://github.com/datdenkikniet/ipmi-rs/pull/6
 [#7]: https://github.com/datdenkikniet/ipmi-rs/pull/7
+[#11]: https://github.com/datdenkikniet/ipmi-rs/pull/11
 
 # [0.2.1](https://github.com/datdenkikniet/ipmi-rs/tree/v0.2.1)
 


### PR DESCRIPTION
We noticed one of our agents was seemingly sending bogus data that didn't match ipmitool. It was fixed by a restart. Looking at the captured data, I can see that the raw_reading value that we were expecting to see from the obviously bogus sensor was being captured by a different sensor up until we restarted our agent.

I can't say for certain that the sequence number is the issue but it seems plausible.