### PR TITLE
Fix: Continue iteration after recoverable errors in SdrIter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Fix: Continue iteration after recoverable errors in SdrIter. ([#23])
+
+[#23]: https://github.com/datdenkikniet/ipmi-rs/pull/23
+
 # [0.3.0](https://github.com/datdenkikniet/ipmi-rs/tree/v0.3.0)
 
 * Support for sending bridged IPMB messages for sensors that are not available on the system


### PR DESCRIPTION
Hi dear @datdenkikniet 

This PR improve the SdrIter implementation where the iterator would stop iterating upon encountering a recoverable error. 

Key changes in this PR:

1 Fix recoverable error handling:

When a recoverable error (IpmiError::ParsingFailed) is encountered, the iterator now skips the current record and continues iterating over subsequent records.
The next_id is updated with the next valid record ID, ensuring the iteration proceeds.

2 Add a limit to recoverable errors:

To prevent potential infinite loops in extreme cases where consecutive recoverable errors occur, a MAX_RECOVERABLE_ERRORS constant is introduced. If the iterator encounters too many recoverable errors, it will log an error and terminate safely.

