### PR TITLE
Slim down `IpmiCommand`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-
       - name: Run `cargo fmt --check`
         run: cargo fmt --check
 
@@ -28,8 +26,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-
-      - uses: dtolnay/rust-toolchain@stable
 
       - name: Run `cargo check --no-default-features --features "${{ matrix.features }}"`
         run: cargo check --no-default-features --features "${{ matrix.features }}" --locked

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,9 @@ jobs:
         features:
           - ""
           - "md5"
+          - "unix-file"
+          - "log-to-file"
+          - "time"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+* BREAKING: Refactor `IpmiCommand` to reduce/remove completion-code validation for ipmlementors. ([#28])
+* BREAKING: Remove `IpmiCommandError`. ([#28])
+* BREAKING: Remove `Success` variant from and rename `CompletionCode` to `CompletionErrorCode`. ([#28])
+
+[#28]: https://github.com/datdenkikniet/ipmi-rs/pull/28
+
 # [0.4.0](https://github.com/datdenkikniet/ipmi-rs/tree/v0.4.0)
 
 * Handle invalid `OwnerKey` while parsing `SensorKey`. ([#25])

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -12,7 +12,7 @@ use ipmi_rs::{
         File, IpmiCommand,
     },
     storage::sdr,
-    Ipmi, IpmiCommandError, IpmiError, SdrIter,
+    Ipmi, IpmiError, SdrIter,
 };
 
 #[allow(unused)]
@@ -43,7 +43,7 @@ impl IpmiConnectionEnum {
     pub fn send_recv<CMD>(
         &mut self,
         request: CMD,
-    ) -> Result<CMD::Output, IpmiCommandError<std::io::Error, CMD::Error>>
+    ) -> Result<CMD::Output, IpmiError<std::io::Error, CMD::Error>>
     where
         CMD: IpmiCommand,
     {

--- a/src/app/auth/activate_session.rs
+++ b/src/app/auth/activate_session.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use crate::connection::{IpmiCommand, Message, NetFn, ParseResponseError};
+use crate::connection::{IpmiCommand, Message, NetFn};
 
 use super::{AuthError, AuthType, PrivilegeLevel};
 
@@ -38,14 +38,9 @@ impl IpmiCommand for ActivateSession {
 
     type Error = AuthError;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
         if data.len() < 10 {
-            return Err(ParseResponseError::NotEnoughData);
+            return Err(AuthError::NotEnoughData);
         }
 
         let auth_type = data[0]

--- a/src/app/auth/get_channel_cipher_suites.rs
+++ b/src/app/auth/get_channel_cipher_suites.rs
@@ -1,6 +1,6 @@
 use crate::connection::{
     rmcp::{AuthenticationAlgorithm, ConfidentialityAlgorithm, IntegrityAlgorithm},
-    Channel, IpmiCommand, Message, NetFn, ParseResponseError,
+    Channel, IpmiCommand, Message, NetFn, NotEnoughData,
 };
 
 #[derive(Debug, Clone)]
@@ -122,16 +122,11 @@ impl core::ops::Deref for ChannelCipherSuites {
 impl IpmiCommand for GetChannelCipherSuites {
     type Output = ChannelCipherSuites;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
         if data.len() > 16 {
-            return Err(ParseResponseError::Parse(()));
+            return Err(NotEnoughData);
         }
 
         let mut record_data = [0u8; 16];

--- a/src/app/auth/get_channel_cipher_suites.rs
+++ b/src/app/auth/get_channel_cipher_suites.rs
@@ -1,6 +1,6 @@
 use crate::connection::{
     rmcp::{AuthenticationAlgorithm, ConfidentialityAlgorithm, IntegrityAlgorithm},
-    Channel, IpmiCommand, Message, NetFn, NotEnoughData,
+    Channel, IpmiCommand, Message, NetFn,
 };
 
 #[derive(Debug, Clone)]
@@ -119,14 +119,17 @@ impl core::ops::Deref for ChannelCipherSuites {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct TooMuchData;
+
 impl IpmiCommand for GetChannelCipherSuites {
     type Output = ChannelCipherSuites;
 
-    type Error = NotEnoughData;
+    type Error = TooMuchData;
 
     fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
         if data.len() > 16 {
-            return Err(NotEnoughData);
+            return Err(TooMuchData);
         }
 
         let mut record_data = [0u8; 16];

--- a/src/app/auth/get_session_challenge.rs
+++ b/src/app/auth/get_session_challenge.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use crate::connection::{CompletionCode, IpmiCommand, Message, NetFn, ParseResponseError};
+use crate::connection::{IpmiCommand, Message, NetFn};
 
 use super::{AuthError, AuthType};
 
@@ -58,14 +58,9 @@ impl IpmiCommand for GetSessionChallenge {
 
     type Error = AuthError;
 
-    fn parse_response(
-        completion_code: CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
         if data.len() != 20 {
-            return Err(ParseResponseError::NotEnoughData);
+            return Err(AuthError::NotEnoughData);
         }
 
         let temporary_session_id =

--- a/src/app/auth/mod.rs
+++ b/src/app/auth/mod.rs
@@ -16,6 +16,9 @@ pub use get_channel_cipher_suites::{ChannelCipherSuites, CipherSuite, GetChannel
 
 #[derive(Debug, Clone)]
 pub enum AuthError {
+    /// One of the exchanged authentication responses did not
+    /// contain enough data to parse the expected message.
+    NotEnoughData,
     /// A non-zero session ID was received at a stage where
     /// non-zero session numbers are not allowed.
     InvalidZeroSession,

--- a/src/app/get_device_id.rs
+++ b/src/app/get_device_id.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{IpmiCommand, Message, NetFn, ParseResponseError},
+    connection::{IpmiCommand, Message, NetFn, NotEnoughData},
     log_vec, Loggable,
 };
 
@@ -14,14 +14,10 @@ impl From<GetDeviceId> for Message {
 impl IpmiCommand for GetDeviceId {
     type Output = DeviceId;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-        DeviceId::from_data(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        DeviceId::from_data(data).ok_or(NotEnoughData)
     }
 }
 

--- a/src/connection/completion_code.rs
+++ b/src/connection/completion_code.rs
@@ -7,6 +7,7 @@ pub enum ResponseUnavailableReason {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(missing_docs)]
 pub enum CompletionCode {
     Success,
     NodeBusy,
@@ -79,10 +80,12 @@ impl From<u8> for CompletionCode {
 }
 
 impl CompletionCode {
+    /// Whether this completion code is a success or not.
     pub fn is_success(&self) -> bool {
         matches!(self, Self::Success)
     }
 
+    /// Whether this completion code is a reserved value or not.
     pub fn is_reserved(&self) -> bool {
         matches!(self, Self::Reserved(_))
     }

--- a/src/connection/completion_code.rs
+++ b/src/connection/completion_code.rs
@@ -8,7 +8,7 @@ pub enum ResponseUnavailableReason {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(missing_docs)]
-pub enum CompletionCode {
+pub enum CompletionErrorCode {
     NodeBusy,
     InvalidCommand,
     InvalidCommandForLun,
@@ -35,7 +35,7 @@ pub enum CompletionCode {
     Reserved(u8),
 }
 
-impl TryFrom<u8> for CompletionCode {
+impl TryFrom<u8> for CompletionErrorCode {
     type Error = ();
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
@@ -82,7 +82,7 @@ impl TryFrom<u8> for CompletionCode {
     }
 }
 
-impl CompletionCode {
+impl CompletionErrorCode {
     /// Whether this completion code is a reserved value or not.
     pub fn is_reserved(&self) -> bool {
         matches!(self, Self::Reserved(_))

--- a/src/connection/completion_code.rs
+++ b/src/connection/completion_code.rs
@@ -9,7 +9,6 @@ pub enum ResponseUnavailableReason {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[allow(missing_docs)]
 pub enum CompletionCode {
-    Success,
     NodeBusy,
     InvalidCommand,
     InvalidCommandForLun,
@@ -36,10 +35,12 @@ pub enum CompletionCode {
     Reserved(u8),
 }
 
-impl From<u8> for CompletionCode {
-    fn from(value: u8) -> Self {
-        match value {
-            0x00 => Self::Success,
+impl TryFrom<u8> for CompletionCode {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        let value = match value {
+            0 => return Err(()),
             0xC0 => Self::NodeBusy,
             0xC1 => Self::InvalidCommand,
             0xC2 => Self::InvalidCommandForLun,
@@ -75,16 +76,13 @@ impl From<u8> for CompletionCode {
             0x01..=0x7E => Self::Oem(value),
             0x80..=0xBE => Self::CommandSpecific(value),
             v => Self::Reserved(v),
-        }
+        };
+
+        Ok(value)
     }
 }
 
 impl CompletionCode {
-    /// Whether this completion code is a success or not.
-    pub fn is_success(&self) -> bool {
-        matches!(self, Self::Success)
-    }
-
     /// Whether this completion code is a reserved value or not.
     pub fn is_reserved(&self) -> bool {
         matches!(self, Self::Reserved(_))

--- a/src/connection/impls/mod.rs
+++ b/src/connection/impls/mod.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 #[cfg(feature = "unix-file")]
 mod file;
 #[cfg(feature = "unix-file")]

--- a/src/connection/impls/rmcp/mod.rs
+++ b/src/connection/impls/rmcp/mod.rs
@@ -1,4 +1,7 @@
-use crate::{connection::IpmiConnection, IpmiCommandError};
+use crate::{
+    connection::{IpmiConnection, NotEnoughData},
+    IpmiError,
+};
 use std::{net::ToSocketAddrs, time::Duration};
 
 mod socket;
@@ -92,7 +95,7 @@ impl From<RmcpIpmiSendError> for RmcpIpmiError {
     }
 }
 
-type CommandError<T> = IpmiCommandError<RmcpIpmiError, T>;
+type CommandError<T> = IpmiError<RmcpIpmiError, T>;
 
 #[derive(Debug)]
 pub enum ActivationError {
@@ -103,7 +106,7 @@ pub enum ActivationError {
     /// The contacted host does not support IPMI over RMCP.
     IpmiNotSupported,
     NoSupportedIpmiLANVersions,
-    GetChannelAuthenticationCapabilities(CommandError<()>),
+    GetChannelAuthenticationCapabilities(CommandError<NotEnoughData>),
     V1_5(V1_5ActivationError),
     V2_0(V2_0ActivationError),
     RmcpError(RmcpHeaderError),

--- a/src/connection/impls/rmcp/v1_5/mod.rs
+++ b/src/connection/impls/rmcp/v1_5/mod.rs
@@ -5,7 +5,7 @@ use crate::{
         ActivateSession, AuthError, AuthType, ChannelAuthenticationCapabilities,
         GetSessionChallenge, PrivilegeLevel,
     },
-    connection::{IpmiConnection, ParseResponseError, Request, Response},
+    connection::{IpmiConnection, Request, Response},
     Ipmi, IpmiError,
 };
 
@@ -28,9 +28,9 @@ pub enum ActivationError {
     Io(std::io::Error),
     PasswordTooLong,
     UsernameTooLong,
-    GetSessionChallenge(IpmiError<RmcpIpmiError, ParseResponseError<AuthError>>),
+    GetSessionChallenge(IpmiError<RmcpIpmiError, AuthError>),
     NoSupportedAuthenticationType,
-    ActivateSession(IpmiError<RmcpIpmiError, ParseResponseError<AuthError>>),
+    ActivateSession(IpmiError<RmcpIpmiError, AuthError>),
 }
 
 #[derive(Debug)]

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -140,6 +140,12 @@ impl LogicalUnit {
     }
 }
 
+impl From<LogicalUnit> for u8 {
+    fn from(value: LogicalUnit) -> Self {
+        value.value()
+    }
+}
+
 pub trait IpmiConnection {
     type SendError: core::fmt::Debug;
     type RecvError: core::fmt::Debug;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,7 +4,7 @@
 mod completion_code;
 use std::num::NonZeroU8;
 
-pub use completion_code::CompletionCode;
+pub use completion_code::CompletionErrorCode;
 
 mod impls;
 
@@ -262,7 +262,10 @@ pub trait IpmiCommand: Into<Message> {
     /// The default implementation of this function performs no special handling
     /// and returns `None`.
     #[allow(unused)]
-    fn handle_completion_code(completion_code: CompletionCode, data: &[u8]) -> Option<Self::Error> {
+    fn handle_completion_code(
+        completion_code: CompletionErrorCode,
+        data: &[u8],
+    ) -> Option<Self::Error> {
         None
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs)]
+//! Implementations & connection-related details.
+
 mod completion_code;
 use std::num::NonZeroU8;
 
@@ -19,9 +22,13 @@ pub use request::{Request, RequestTargetAddress};
 mod response;
 pub use response::Response;
 
+/// The address of an IPMI module or sensor.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Address(pub u8);
 
+/// A numbered channel.
+///
+/// The value of a channel is always less than `0xB`.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct ChannelNumber(NonZeroU8);
 
@@ -46,18 +53,23 @@ impl ChannelNumber {
     }
 }
 
+/// The channel on which an IPMI module or sensor is present.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum Channel {
+    /// The primary channel.
     Primary,
+    /// A numbered channel.
     Numbered(ChannelNumber),
+    /// The system channel.
     System,
+    /// The current channel, for some definition of current.
     Current,
 }
 
 impl Channel {
     /// Create a new `Channel`.
     ///
-    /// This function returns `None` if `value == 0xC` || value == 0xD || value > 0xF`
+    /// This function returns `None` for invalid channel values. `value` is invalid if `value == 0xC || value == 0xD || value > 0xF`.
     pub fn new(value: u8) -> Option<Self> {
         match value {
             0 => Some(Self::Primary),
@@ -70,8 +82,7 @@ impl Channel {
     /// The number of this channel.
     ///
     /// This value is guaranteed to be less than or
-    /// equal to 0xF, and will be 0xE if `self` is
-    /// [`Channel::Current`].
+    /// equal to 0xF.
     pub fn value(&self) -> u8 {
         match self {
             Channel::Primary => 0x0,
@@ -93,7 +104,9 @@ impl core::fmt::Display for Channel {
     }
 }
 
+/// The logical unit of an IPMI module/sensor.
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(missing_docs)]
 pub enum LogicalUnit {
     Zero,
     One,
@@ -130,6 +143,9 @@ impl TryFrom<u8> for LogicalUnit {
 }
 
 impl LogicalUnit {
+    /// Get a raw value describing this logical unit.
+    ///
+    /// This value is always in the range `0..=3`.
     pub fn value(&self) -> u8 {
         match self {
             LogicalUnit::Zero => 0,
@@ -146,16 +162,26 @@ impl From<LogicalUnit> for u8 {
     }
 }
 
+/// A trait describing operations that can be performed on an IPMI connection.
 pub trait IpmiConnection {
+    /// The type of error the can occur when sending a [`Request`].
     type SendError: core::fmt::Debug;
+    /// The type of error that can occur when receiving a [`Response`].
     type RecvError: core::fmt::Debug;
+    /// The type of error the can occur when sending a [`Request`] or receiving a [`Response`].
     type Error: core::fmt::Debug + From<Self::SendError> + From<Self::RecvError>;
 
+    /// Send `request` to the remote end of this connection.
     fn send(&mut self, request: &mut Request) -> Result<(), Self::SendError>;
+
+    /// Receive a response from the remote end of this connection.
     fn recv(&mut self) -> Result<Response, Self::RecvError>;
+
+    /// Send `request` to and reveive a response from the remote end of this connection.
     fn send_recv(&mut self, request: &mut Request) -> Result<Response, Self::Error>;
 }
 
+/// The wire representation of an IPMI messag.e
 #[derive(Clone, Debug, PartialEq)]
 pub struct Message {
     netfn: u8,
@@ -164,6 +190,7 @@ pub struct Message {
 }
 
 impl Message {
+    /// Create a new request message with the provided `netfn`, `cmd` and `data`.
     pub fn new_request(netfn: NetFn, cmd: u8, data: Vec<u8>) -> Self {
         Self {
             netfn: netfn.request_value(),
@@ -172,6 +199,7 @@ impl Message {
         }
     }
 
+    /// Create a new response message with the provided `netfn`, `cmd` and `data`.
     pub fn new_response(netfn: NetFn, cmd: u8, data: Vec<u8>) -> Self {
         Self {
             netfn: netfn.response_value(),
@@ -180,35 +208,45 @@ impl Message {
         }
     }
 
+    /// Create a new message with the provided raw `netfn`, `cmd` and `data`.
     pub fn new_raw(netfn: u8, cmd: u8, data: Vec<u8>) -> Self {
         Self { netfn, cmd, data }
     }
 
+    /// Get the netfn of the message.
     pub fn netfn(&self) -> NetFn {
         NetFn::from(self.netfn)
     }
 
+    /// Get the raw netfn value for the message.
     pub fn netfn_raw(&self) -> u8 {
         self.netfn
     }
 
+    /// Get the command value for this message.
     pub fn cmd(&self) -> u8 {
         self.cmd
     }
 
+    /// Get a reference to the data for this message.
     pub fn data(&self) -> &[u8] {
         &self.data
     }
 
+    /// Get a mutable reference to the data for this message.
     pub fn data_mut(&mut self) -> &mut [u8] {
         &mut self.data
     }
 }
 
+/// Generic errors that can occur while parsing a [`Response`].
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ParseResponseError<T> {
+    /// An error, described by a [`CompletionCode`], occurred.
     Failed(CompletionCode),
+    /// There was not enough data to parse the expected [`Response`].
     NotEnoughData,
+    /// A different parsing error occurred.
     Parse(T),
 }
 
@@ -218,15 +256,25 @@ impl<T> From<T> for ParseResponseError<T> {
     }
 }
 
+/// An IPMI command that can be turned into a request, and whose response can be parsed
+/// from response data.
 pub trait IpmiCommand: Into<Message> {
+    /// The output of this command, i.e. the expected response type.
     type Output;
+    /// The type of error that can occur while parsing the response for this
+    /// command.
     type Error;
 
+    /// Try to parse the expected response for this command from the
+    /// provided [`CompletionCode`] and `data`.
+    // TODO: `parse_response` should only be called if `completion_code` is valid (i.e. only impl `parse_valid_response(&[u8])`)
     fn parse_response(
         completion_code: CompletionCode,
         data: &[u8],
     ) -> Result<Self::Output, ParseResponseError<Self::Error>>;
 
+    /// Convenience function for validating that `cc` is valid, and returning the appropriate
+    /// error otherwise.
     fn check_cc_success(cc: CompletionCode) -> Result<(), ParseResponseError<Self::Error>> {
         if cc.is_success() {
             Ok(())
@@ -235,6 +283,7 @@ pub trait IpmiCommand: Into<Message> {
         }
     }
 
+    /// Get the intended target [`Address`] and [`Channel`] for this commmand.
     fn target(&self) -> Option<(Address, Channel)> {
         None
     }

--- a/src/connection/netfn.rs
+++ b/src/connection/netfn.rs
@@ -1,8 +1,10 @@
 macro_rules! netfn {
     ($($name:ident => [$req:literal | $resp:literal]),*) => {
         #[derive(Debug, Clone, Copy, PartialEq)]
+        #[allow(missing_docs)]
         pub enum NetFn {
             $($name,)*
+            /// A reserved netfn.
             Reserved(u8),
         }
 
@@ -16,14 +18,18 @@ macro_rules! netfn {
         }
 
         impl NetFn {
+            // TODO: give these two fns their own impl block.
+            /// Check whether `v` is a response value.
             pub fn is_response_value(v: u8) -> bool {
                 v % 2 == 0
             }
 
+            /// Check whether `v` is a request value.
             pub fn is_request_value(v: u8) -> bool {
                 !Self::is_response_value(v)
             }
 
+            /// Get the raw data for the request value of this netfn.
             pub fn request_value(&self) -> u8 {
                 match self {
                     $(Self::$name => $req,)*
@@ -37,6 +43,7 @@ macro_rules! netfn {
                 }
             }
 
+            /// Get the raw data for the response value of this netfn.
             pub fn response_value(&self) -> u8 {
                 match self {
                     $(Self::$name => $resp,)*

--- a/src/connection/netfn.rs
+++ b/src/connection/netfn.rs
@@ -18,17 +18,6 @@ macro_rules! netfn {
         }
 
         impl NetFn {
-            // TODO: give these two fns their own impl block.
-            /// Check whether `v` is a response value.
-            pub fn is_response_value(v: u8) -> bool {
-                v % 2 == 0
-            }
-
-            /// Check whether `v` is a request value.
-            pub fn is_request_value(v: u8) -> bool {
-                !Self::is_response_value(v)
-            }
-
             /// Get the raw data for the request value of this netfn.
             pub fn request_value(&self) -> u8 {
                 match self {
@@ -69,3 +58,15 @@ netfn!(
     Storage => [0x0A | 0x0B],
     Transport => [0x0C | 0x0D]
 );
+
+impl NetFn {
+    /// Check whether `v` is a response value.
+    pub fn is_response_value(v: u8) -> bool {
+        v % 2 == 0
+    }
+
+    /// Check whether `v` is a request value.
+    pub fn is_request_value(v: u8) -> bool {
+        !Self::is_response_value(v)
+    }
+}

--- a/src/connection/request.rs
+++ b/src/connection/request.rs
@@ -2,12 +2,16 @@ use crate::connection::{LogicalUnit, NetFn};
 
 use super::{Address, Channel, Message};
 
+/// An IPMI request message.
 pub struct Request {
     target: RequestTargetAddress,
     message: Message,
 }
 
 impl Request {
+    /// Create a new IPMI request message.
+    ///
+    /// The netfn for `request` should be of the `request` variant, see [`Message::new_request`].
     pub const fn new(request: Message, target: RequestTargetAddress) -> Self {
         Self {
             target,
@@ -15,38 +19,49 @@ impl Request {
         }
     }
 
+    /// Get the netfn for the request.
     pub fn netfn(&self) -> NetFn {
         self.message.netfn()
     }
 
+    /// Get the raw value of the netfn for the request.
     pub fn netfn_raw(&self) -> u8 {
         self.message.netfn_raw()
     }
 
+    /// Get the command value for the request.
     pub fn cmd(&self) -> u8 {
         self.message.cmd
     }
+
+    /// Get a shared reference to the data of the request (does not include netfn or command).
 
     pub fn data(&self) -> &[u8] {
         self.message.data()
     }
 
+    /// Get a mutable reference to the data of the request (does not include netfn or command).
     pub fn data_mut(&mut self) -> &mut [u8] {
         self.message.data_mut()
     }
 
+    /// Get the target for the request.
     pub fn target(&self) -> RequestTargetAddress {
         self.target
     }
 }
 
+/// The target address of a request.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum RequestTargetAddress {
+    /// A logical unit on the BMC (Board Management Controller).
     Bmc(LogicalUnit),
+    /// An address on the BMC or IPMB.
     BmcOrIpmb(Address, Channel, LogicalUnit),
 }
 
 impl RequestTargetAddress {
+    /// Get the logical unit for the target address.
     pub fn lun(&self) -> LogicalUnit {
         match self {
             RequestTargetAddress::Bmc(lun) | RequestTargetAddress::BmcOrIpmb(_, _, lun) => *lun,

--- a/src/connection/response.rs
+++ b/src/connection/response.rs
@@ -2,6 +2,7 @@ use crate::NetFn;
 
 use super::Message;
 
+/// An IPMI response.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Response {
     seq: i64,
@@ -9,6 +10,9 @@ pub struct Response {
 }
 
 impl Response {
+    /// Create a new IPMI request message.
+    ///
+    /// The netfn for `request` should be of the `request` variant, see [`Message::new_response`].
     pub fn new(message: Message, seq: i64) -> Option<Self> {
         if !message.data().is_empty() {
             Some(Self { message, seq })
@@ -16,27 +20,32 @@ impl Response {
             None
         }
     }
-
+    /// Get the netfn for the request.
     pub fn netfn(&self) -> NetFn {
         self.message.netfn()
     }
 
+    /// Get the raw value of the netfn for the request.
     pub fn netfn_raw(&self) -> u8 {
         self.message.netfn_raw()
     }
 
+    /// Get the command value for the request.
     pub fn cmd(&self) -> u8 {
         self.message.cmd
     }
 
+    /// Get the sequence number for the response.
     pub fn seq(&self) -> i64 {
         self.seq
     }
 
+    /// Get the completion code for the response.
     pub fn cc(&self) -> u8 {
         self.message.data[0]
     }
 
+    /// Get a shared reference to the data of the request (does not include netfn or command).
     pub fn data(&self) -> &[u8] {
         &self.message.data[1..]
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::connection::NetFn;
+use crate::connection::{CompletionCode, NetFn};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum IpmiError<CON, P> {
@@ -12,14 +12,14 @@ pub enum IpmiError<CON, P> {
     Failed {
         netfn: NetFn,
         cmd: u8,
-        completion_code: u8,
+        completion_code: CompletionCode,
         data: Vec<u8>,
     },
-    ParsingFailed {
+    Command {
         error: P,
         netfn: NetFn,
         cmd: u8,
-        completion_code: u8,
+        completion_code: Option<CompletionCode>,
         data: Vec<u8>,
     },
     Connection(CON),
@@ -49,13 +49,13 @@ impl<CON, P> IpmiError<CON, P> {
                 cmd_sent,
                 cmd_recvd,
             },
-            IpmiError::ParsingFailed {
+            IpmiError::Command {
                 error,
                 netfn,
                 cmd,
                 completion_code,
                 data,
-            } => IpmiError::ParsingFailed {
+            } => IpmiError::Command {
                 error,
                 netfn,
                 cmd,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::connection::{CompletionCode, NetFn};
+use crate::connection::{CompletionErrorCode, NetFn};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum IpmiError<CON, P> {
@@ -12,14 +12,14 @@ pub enum IpmiError<CON, P> {
     Failed {
         netfn: NetFn,
         cmd: u8,
-        completion_code: CompletionCode,
+        completion_code: CompletionErrorCode,
         data: Vec<u8>,
     },
     Command {
         error: P,
         netfn: NetFn,
         cmd: u8,
-        completion_code: Option<CompletionCode>,
+        completion_code: Option<CompletionErrorCode>,
         data: Vec<u8>,
     },
     Connection(CON),

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,12 @@ pub enum IpmiError<CON, P> {
         cmd_sent: u8,
         cmd_recvd: u8,
     },
+    Failed {
+        netfn: NetFn,
+        cmd: u8,
+        completion_code: u8,
+        data: Vec<u8>,
+    },
     ParsingFailed {
         error: P,
         netfn: NetFn,
@@ -51,6 +57,17 @@ impl<CON, P> IpmiError<CON, P> {
                 data,
             } => IpmiError::ParsingFailed {
                 error,
+                netfn,
+                cmd,
+                completion_code,
+                data,
+            },
+            IpmiError::Failed {
+                netfn,
+                cmd,
+                completion_code,
+                data,
+            } => IpmiError::Failed {
                 netfn,
                 cmd,
                 completion_code,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,9 @@ mod tests;
 
 pub use fmt::{LogOutput, Loggable, Logger};
 
-use connection::{CompletionCode, IpmiCommand, LogicalUnit, NetFn, Request, RequestTargetAddress};
+use connection::{
+    CompletionErrorCode, IpmiCommand, LogicalUnit, NetFn, Request, RequestTargetAddress,
+};
 use storage::sdr::{self, record::Record as SdrRecord};
 
 pub struct Ipmi<CON> {
@@ -93,7 +95,7 @@ where
             data: response.data().to_vec(),
         };
 
-        if let Ok(completion_code) = CompletionCode::try_from(response.cc()) {
+        if let Ok(completion_code) = CompletionErrorCode::try_from(response.cc()) {
             let error = CMD::handle_completion_code(completion_code, response.data())
                 .map(|e| IpmiError::Command {
                     error: e,

--- a/src/sensor_event/sensor_reading/get.rs
+++ b/src/sensor_event/sensor_reading/get.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{Address, Channel, CompletionCode, IpmiCommand, Message, ParseResponseError},
+    connection::{Address, Channel, IpmiCommand, Message, NotEnoughData},
     storage::sdr::record::{SensorKey, SensorNumber},
 };
 
@@ -72,15 +72,10 @@ impl From<GetSensorReading> for Message {
 impl IpmiCommand for GetSensorReading {
     type Output = RawSensorReading;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
-        RawSensorReading::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        RawSensorReading::parse(data).ok_or(NotEnoughData)
     }
 
     fn target(&self) -> Option<(Address, Channel)> {

--- a/src/storage/sdr/get_alloc_info.rs
+++ b/src/storage/sdr/get_alloc_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{IpmiCommand, Message, NetFn, ParseResponseError},
+    connection::{IpmiCommand, Message, NetFn, NotEnoughData},
     Loggable,
 };
 
@@ -15,15 +15,10 @@ impl From<GetAllocInfo> for Message {
 impl IpmiCommand for GetAllocInfo {
     type Output = AllocInfo;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
-        AllocInfo::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        AllocInfo::parse(data).ok_or(NotEnoughData)
     }
 }
 

--- a/src/storage/sdr/get_dev_sdr_info.rs
+++ b/src/storage/sdr/get_dev_sdr_info.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{
-    connection::{CompletionCode, IpmiCommand, LogicalUnit, Message, NetFn, ParseResponseError},
+    connection::{IpmiCommand, LogicalUnit, Message, NetFn, NotEnoughData},
     log_vec, Loggable,
 };
 
@@ -162,29 +162,19 @@ impl From<GetDeviceSdrInfo<SensorCount>> for Message {
 impl IpmiCommand for GetDeviceSdrInfo<SdrCount> {
     type Output = DeviceSdrInfo<NumberOfSdrs>;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
-        DeviceSdrInfo::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        DeviceSdrInfo::parse(data).ok_or(NotEnoughData)
     }
 }
 
 impl IpmiCommand for GetDeviceSdrInfo<SensorCount> {
     type Output = DeviceSdrInfo<NumberOfSensors>;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
-        DeviceSdrInfo::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        DeviceSdrInfo::parse(data).ok_or(NotEnoughData)
     }
 }

--- a/src/storage/sdr/get_info.rs
+++ b/src/storage/sdr/get_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{IpmiCommand, Message, NetFn, ParseResponseError},
+    connection::{IpmiCommand, Message, NetFn, NotEnoughData},
     fmt::LogItem,
     log_vec,
     storage::Timestamp,
@@ -17,15 +17,10 @@ impl From<GetRepositoryInfo> for Message {
 impl IpmiCommand for GetRepositoryInfo {
     type Output = RepositoryInfo;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
-        RepositoryInfo::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        RepositoryInfo::parse(data).ok_or(NotEnoughData)
     }
 }
 

--- a/src/storage/sel/get_alloc_info.rs
+++ b/src/storage/sel/get_alloc_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{IpmiCommand, Message, NetFn, ParseResponseError},
+    connection::{IpmiCommand, Message, NetFn, NotEnoughData},
     Loggable,
 };
 
@@ -8,15 +8,10 @@ pub struct GetAllocInfo;
 impl IpmiCommand for GetAllocInfo {
     type Output = AllocInfo;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-
-        AllocInfo::parse(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        AllocInfo::parse(data).ok_or(NotEnoughData)
     }
 }
 

--- a/src/storage/sel/get_info.rs
+++ b/src/storage/sel/get_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    connection::{IpmiCommand, Message, NetFn, ParseResponseError},
+    connection::{IpmiCommand, Message, NetFn, NotEnoughData},
     log_vec,
     storage::Timestamp,
     Loggable,
@@ -10,14 +10,10 @@ pub struct GetInfo;
 impl IpmiCommand for GetInfo {
     type Output = Info;
 
-    type Error = ();
+    type Error = NotEnoughData;
 
-    fn parse_response(
-        completion_code: crate::connection::CompletionCode,
-        data: &[u8],
-    ) -> Result<Self::Output, ParseResponseError<Self::Error>> {
-        Self::check_cc_success(completion_code)?;
-        Info::from_data(data).ok_or(ParseResponseError::NotEnoughData)
+    fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error> {
+        Info::from_data(data).ok_or(NotEnoughData)
     }
 }
 


### PR DESCRIPTION
`IpmiCommand` implementors should not have to deal with completion codes directly, unless there are command-specific completion codes to be handled.