### PR TITLE
sel: Fix capabilities bit, change Clear to Delete

### DIFF
--- a/ipmi-rs-core/src/storage/sel/get_info.rs
+++ b/ipmi-rs-core/src/storage/sel/get_info.rs
@@ -21,9 +21,14 @@ impl From<GetInfo> for Message {
     }
 }
 
+/// Optional SEL commands whose support is advertised by the Operation Support
+/// byte of the Get SEL Info response.
+///
+/// Reference: IPMI 2.0 Specification, Section 31.2, Table 31-2 "Get SEL Info
+/// Command".
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Command {
-    Clear,
+    Delete,
     PartialAddEntry,
     Reserve,
     GetAllocInfo,
@@ -60,7 +65,7 @@ impl Info {
         let mut supported_cmds = Vec::with_capacity(4);
 
         if data[13] & 0x08 == 0x08 {
-            supported_cmds.push(Command::Clear);
+            supported_cmds.push(Command::Delete);
         }
         if data[13] & 0x04 == 0x04 {
             supported_cmds.push(Command::PartialAddEntry);

--- a/ipmi-rs-log/src/impls.rs
+++ b/ipmi-rs-log/src/impls.rs
@@ -28,7 +28,7 @@ impl Loggable for SelInfo {
             .iter()
             .map(|cmd| match cmd {
                 SelCommand::GetAllocInfo => "Get Alloc Info",
-                SelCommand::Clear => "Clear",
+                SelCommand::Delete => "Delete",
                 SelCommand::PartialAddEntry => "Partial Add",
                 SelCommand::Reserve => "Reserve",
             })

--- a/ipmi-rs/examples/sel.rs
+++ b/ipmi-rs/examples/sel.rs
@@ -382,12 +382,6 @@ fn main() -> std::io::Result<()> {
     }
 
     if opts.clear {
-        // Clear SEL
-        if !info.supported_cmds.contains(&SelCommand::Clear) {
-            log::error!("SEL Clear command is not supported by this BMC");
-            return Ok(());
-        }
-
         if !info.supported_cmds.contains(&SelCommand::Reserve) {
             log::error!("SEL Reserve command is not supported by this BMC");
             return Ok(());


### PR DESCRIPTION
During development of my own IPMI config tool i noticed sel clear does't work. Reason is that clear is interpreted as optional command and allowed only if capabilities bit present, while this bit actually indicate presence of Delete command, and Clear is mandatory by specification.