### PR TITLE
sensor: fix lower-critical threshold status mask

### DIFF
--- a/ipmi-rs-core/src/sensor_event/sensor_reading/mod.rs
+++ b/ipmi-rs-core/src/sensor_event/sensor_reading/mod.rs
@@ -48,7 +48,7 @@ impl From<&RawSensorReading> for ThresholdReading {
                 at_or_above_upper_critical: (d & 0x10 == 0x10),
                 at_or_above_upper_non_critical: (d & 0x08) == 0x08,
                 at_or_below_lower_non_recoverable: (d & 0x04) == 0x04,
-                at_or_below_lower_critical: (d & 0x20) == 0x20,
+                at_or_below_lower_critical: (d & 0x02) == 0x02,
                 at_or_below_lower_non_critical: (d & 0x01) == 0x01,
             })
         };
@@ -73,5 +73,27 @@ impl FromSensorReading for ThresholdReading {
 
     fn from(_: &Self::Sensor, in_reading: &RawSensorReading) -> Self {
         in_reading.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawSensorReading, ThresholdReading};
+
+    #[test]
+    fn lower_critical_uses_bit_one() {
+        let raw_reading = RawSensorReading::parse(&[0x00, 0xC0, 0x02]).unwrap();
+        let reading = ThresholdReading::from(&raw_reading);
+        let status = reading.threshold_status.unwrap();
+
+        assert!(status.at_or_below_lower_critical);
+        assert!(!status.at_or_above_non_recoverable);
+
+        let raw_reading = RawSensorReading::parse(&[0x00, 0xC0, 0x20]).unwrap();
+        let reading = ThresholdReading::from(&raw_reading);
+        let status = reading.threshold_status.unwrap();
+
+        assert!(!status.at_or_below_lower_critical);
+        assert!(status.at_or_above_non_recoverable);
     }
 }


### PR DESCRIPTION
The Get Sensor Reading threshold-status decoder tested lower critical with 0x20. That is bit 5, so lower critical incorrectly mirrored upper non-recoverable: an isolated lower-critical status (0x02) was missed, while an upper-non-recoverable status (0x20) produced a false lower-critical result.

IPMI v2.0 specification reference:

- Section 35.14, Get Sensor Reading Command
- Table 35-15
- Printed page 468 (PDF page 494)
- Response data byte 4: `For threshold-based sensors
Present threshold comparison status`

The specification defines:

[7:6 reserved]
[5] upper non-recoverable
[4] upper critical
[3] upper non-critical
[2] lower non-recoverable
[1] lower critical
[0] lower non-critical

Therefore:

lower_critical = (status & 0x02) != 0;

ipmi-rs implementation used 0x20 in ipmi-rs-core/src/sensor_event/sensor_reading/mod.rs, which is bit 5: upper non-recoverable, so it need minor fix.

Use the correct 0x02 mask and add a regression test proving that bits 1 and 5 independently set lower-critical and upper-non-recoverable status.