### PR TITLE
Fix a bunch of spelling mistakes

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,0 +1,19 @@
+name: Spelling
+
+permissions:
+  contents: read
+
+on: [pull_request]
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v5
+    - name: Spell Check Repo
+      uses: crate-ci/typos@v1.48.0

--- a/ipmi-rs-core/src/app/auth/activate_session.rs
+++ b/ipmi-rs-core/src/app/auth/activate_session.rs
@@ -7,7 +7,7 @@ use super::{AuthError, AuthType, PrivilegeLevel};
 #[derive(Debug, Clone)]
 pub struct ActivateSession {
     pub auth_type: AuthType,
-    pub maxiumum_privilege_level: PrivilegeLevel,
+    pub maximum_privilege_level: PrivilegeLevel,
     pub challenge_string: [u8; 16],
     pub initial_sequence_number: u32,
 }
@@ -25,7 +25,7 @@ impl From<ActivateSession> for Message {
         let mut data = vec![0u8; 22];
 
         data[0] = value.auth_type.into();
-        data[1] = value.maxiumum_privilege_level.into();
+        data[1] = value.maximum_privilege_level.into();
         data[2..18].copy_from_slice(&value.challenge_string);
         data[18..22].copy_from_slice(&value.initial_sequence_number.to_le_bytes());
 

--- a/ipmi-rs-core/src/app/get_device_id.rs
+++ b/ipmi-rs-core/src/app/get_device_id.rs
@@ -29,7 +29,7 @@ pub struct DeviceId {
     pub device_revision: u8,
     /// `true` if the device provides device SDRs.
     pub provides_device_sdrs: bool,
-    /// `true` if the device is availalbe, `false` if the device
+    /// `true` if the device is available, `false` if the device
     /// is in device firmware, SDR repository update, or self-initialization state.
     pub device_available: bool,
     /// The major version of the firmware revision of the device.

--- a/ipmi-rs-core/src/connection/mod.rs
+++ b/ipmi-rs-core/src/connection/mod.rs
@@ -175,11 +175,11 @@ pub trait IpmiConnection {
     /// Receive a response from the remote end of this connection.
     fn recv(&mut self) -> Result<Response, Self::RecvError>;
 
-    /// Send `request` to and reveive a response from the remote end of this connection.
+    /// Send `request` to and receive a response from the remote end of this connection.
     fn send_recv(&mut self, request: &mut Request) -> Result<Response, Self::Error>;
 }
 
-/// The wire representation of an IPMI messag.e
+/// The wire representation of an IPMI message.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Message {
     netfn: u8,
@@ -266,7 +266,7 @@ pub trait IpmiCommand: Into<Message> {
     /// provided `data`, assuming a successful completion code.
     fn parse_success_response(data: &[u8]) -> Result<Self::Output, Self::Error>;
 
-    /// Get the intended target [`Address`] and [`Channel`] for this commmand.
+    /// Get the intended target [`Address`] and [`Channel`] for this command.
     fn target(&self) -> Option<(Address, Channel)> {
         None
     }

--- a/ipmi-rs-core/src/storage/sdr/units.rs
+++ b/ipmi-rs-core/src/storage/sdr/units.rs
@@ -124,7 +124,7 @@ macro_rules ! unit {
 
 unit! {
     Unspecified = [0, None, "Unspecified", "Unspecified"],
-    DegreesCelcius = [1, Some("°C"), "Degree Celcius", "Degrees Celcius"],
+    DegreesCelsius = [1, Some("°C"), "Degree Celsius", "Degrees Celsius"],
     DegreesFahrenheit = [2, Some("°F"), "Degree Fahrenheit", "Degrees Fahrenheit"],
     DegreesKelvin = [3, Some("°K"), "Degree Kelvin", "Degrees Kelvin"],
     Volt = [4, Some("V"), "Volt", "Volts"],
@@ -208,7 +208,7 @@ unit! {
     Underrun = [83, None, "Underrun", "Underruns"],
     Collision = [84, None, "Collision", "Collisions"],
     Packet = [85, None, "Packet", "Packets"],
-    Message = [86, None, "Message", "Messges"],
+    Message = [86, None, "Message", "Messages"],
     Character = [87, None, "Character", "Characters"],
     Error = [88, None, "Error", "Errors"],
     CorrectableError = [89, None, "Correctable Error", "Correctable Errors"],
@@ -221,9 +221,9 @@ unit! {
 fn display_tests() {
     use Unit::*;
 
-    assert_eq!("32 °C", DegreesCelcius.display(true, 32));
-    assert_eq!("32 Degrees Celcius", DegreesCelcius.display(false, 32));
-    assert_eq!("1 Degree Celcius", DegreesCelcius.display(false, 1));
+    assert_eq!("32 °C", DegreesCelsius.display(true, 32));
+    assert_eq!("32 Degrees Celsius", DegreesCelsius.display(false, 32));
+    assert_eq!("1 Degree Celsius", DegreesCelsius.display(false, 1));
     assert_eq!("-1 Nit", Nit.display(true, -1));
     assert_eq!("-1 Nit", Nit.display(false, -1));
     assert_eq!("-15 Nits", Nit.display(false, -15));

--- a/ipmi-rs/src/rmcp/v1_5/mod.rs
+++ b/ipmi-rs/src/rmcp/v1_5/mod.rs
@@ -138,7 +138,7 @@ impl State {
 
         let activate_session: ActivateSession = ActivateSession {
             auth_type: activation_auth_type,
-            maxiumum_privilege_level: privilege_level,
+            maximum_privilege_level: privilege_level,
             challenge_string: challenge.challenge_string,
             initial_sequence_number: 0xDEAD_BEEF,
         };

--- a/ipmi-rs/src/rmcp/v1_5/mod.rs
+++ b/ipmi-rs/src/rmcp/v1_5/mod.rs
@@ -153,7 +153,7 @@ impl State {
             Err(e) => return Err(ActivationError::ActivateSession(e)),
         };
 
-        log::debug!("Succesfully started a session ({:?})", activation_info);
+        log::debug!("Successfully started a session ({:?})", activation_info);
 
         self = ipmi.release();
 
@@ -179,7 +179,7 @@ impl IpmiConnection for State {
         let request_sequence = &mut self.session_sequence;
 
         // Only increment the request sequence once a session has been established
-        // succesfully.
+        // successfully.
         if self.session_id.is_some() {
             *request_sequence = request_sequence.wrapping_add(1);
         }

--- a/ipmi-rs/src/rmcp/v2_0/messages/rakp_3.rs
+++ b/ipmi-rs/src/rmcp/v2_0/messages/rakp_3.rs
@@ -15,7 +15,7 @@ impl RakpMessage3<'_> {
 
         let (status, after_id) = match &self.contents {
             RakpMessage3Contents::Failure(status) => ((*status).into(), &[][..]),
-            RakpMessage3Contents::Succes(data) => (0x00, *data),
+            RakpMessage3Contents::Success(data) => (0x00, *data),
         };
 
         // Status code: success
@@ -34,7 +34,7 @@ impl RakpMessage3<'_> {
 
 pub enum RakpMessage3Contents<'a> {
     Failure(RakpMessage3ErrorStatusCode),
-    Succes(&'a [u8]),
+    Success(&'a [u8]),
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/ipmi-rs/src/rmcp/v2_0/mod.rs
+++ b/ipmi-rs/src/rmcp/v2_0/mod.rs
@@ -360,7 +360,7 @@ impl State {
             RakpMessage3 {
                 message_tag: 0x0A,
                 managed_system_session_id: response.managed_system_session_id,
-                contents: RakpMessage3Contents::Succes(m3),
+                contents: RakpMessage3Contents::Success(m3),
             }
         } else {
             log::warn!("Received RAKP message 2 with invalid integrity check value.");

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,4 @@
+[default]
+
+[default.extend-words]
+Ba = "Ba"


### PR DESCRIPTION
This is more or less a drive by fix.
I was doing some spell checking of an upstream project [siomon](https://github.com/level1techs/siomon/pull/69) and noticed some spelling issues in the API (mainly `Celcius` should be `Celsius`).
The amazing [typos](https://github.com/crate-ci/typos) spell checker was used in finding the mistakes ;)
If needed a [GitHub action](https://github.com/crate-ci/typos/blob/master/docs/github-action.md) is available too.

This introduces user facing changes.